### PR TITLE
github/workflows/main: migrate to rs-toolchain

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           go-version: "1.x"
 
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: fsouza/rs-toolchain@v1.1.0
         with:
           toolchain: stable
           default: true


### PR DESCRIPTION
I'm tired of those warnings, let me fork it.