### PR TITLE
nvim: migrate to packer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,15 @@ FENNEL := $(NVIM_CACHE_DIR)/hr/bin/fennel
 PYTHON ?= python3.11
 
 .PHONY: all
-all: bootstrap-nvim update-paq update-treesitter kill-daemons clear-logs
+all: bootstrap-nvim update-packer update-treesitter kill-daemons clear-logs
 
 .PHONY: bootstrap-nvim
 bootstrap-nvim:
 	$(PYTHON) nvim/scripts/bootstrap.py
 
-.PHONY: update-paq
-update-paq: install
-	env BOOTSTRAP_PAQ=1 nvim --headless -E +'autocmd User PaqDoneSync quit' || true
+.PHONY: update-packer
+update-packer: install
+	env BOOTSTRAP_PACKER=1 nvim --headless -E +'autocmd User PackerComplete quit' || true
 
 .PHONY: update-treesitter
 update-treesitter:

--- a/nvim/lua/fsouza/init.fnl
+++ b/nvim/lua/fsouza/init.fnl
@@ -12,13 +12,13 @@
      (tset package :cpath (table.concat [(.. lib-path# :/?.so) package.cpath]
                                         ";"))))
 
-(macro add-paqs-opt-to-path []
+(macro add-pkgs-opt-to-path []
   `(let [path# (require :fsouza.pl.path)
          packed# (require :fsouza.packed)
-         opt-dir# (path#.join packed#.paq-dir :opt)]
-     (each [_# paq# (ipairs packed#.paqs)]
-       (when (and paq#.opt paq#.as)
-         (let [paq-dir# (path#.join opt-dir# paq#.as)]
+         opt-dir# (path#.join packed#.packer-dir :opt)]
+     (each [_# pkg# (ipairs packed#.pkgs)]
+       (when (and pkg#.opt pkg#.as)
+         (let [paq-dir# (path#.join opt-dir# pkg#.as)]
            (tset package :path
                  (table.concat [package.path
                                 (path#.join paq-dir# :lua :?.lua)
@@ -143,13 +143,13 @@
       (global cache-dir (vim.fn.stdpath :cache))
       (global data-dir (vim.fn.stdpath :data))
       (hererocks)
-      (add-paqs-opt-to-path)
+      (add-pkgs-opt-to-path)
       (initial-mappings)
       (vim-schedule (set-global-options) (set-global-mappings)
                     (override-ui-functions))
       (set-ui-options)
       (set-neovim-global-vars)
-      (if vim.env.BOOTSTRAP_PAQ
+      (if vim.env.BOOTSTRAP_PACKER
           (mod-invoke :fsouza.packed :setup)
           (require :fsouza.plugin)))
     (error "missing FSOUZA_DOTFILES_DIR\n"))


### PR DESCRIPTION
I know packer is bloated, but I can use it for the simple stuff and get it out of my way otherwise, which is fine. The way I'm using it, it's basically paq-nvim with some of the features that I had to fork paq-nvim to implement.